### PR TITLE
chore: add devEngines.packageManager to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,12 @@
     "fs-extra": "^0.26.2",
     "image-size": "^0.5.0",
     "recursive-readdir": "^2.1.0"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.11.0",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
This PR adds `devEngines.packageManager` to package.json to enforce npm version.